### PR TITLE
Fix recursive call in structure_pair to pass tokenizer parameter

### DIFF
--- a/src/models/run_pairwise_classification.py
+++ b/src/models/run_pairwise_classification.py
@@ -278,7 +278,7 @@ def structure_pair(mention_1, mention_2, doc_dict, tokenizer, window):
         }
     except Exception:
         if window > 0:
-            return structure_pair(mention_1, mention_2, doc_dict, window - 1)
+            return structure_pair(mention_1, mention_2, doc_dict, tokenizer, window - 1)
         else:
             traceback.print_exc()
             sys.exit()


### PR DESCRIPTION
the recursive call to structure_pair did not pass the tokenizer parameter.