### PR TITLE
Fix Missing Tokenizer Parameter in evaluate()

### DIFF
--- a/src/models/run_pairwise_classification.py
+++ b/src/models/run_pairwise_classification.py
@@ -1104,6 +1104,7 @@ def train_model(train_data, dev_data, test_data, tokenizer, candidate_generator,
                 dev_docs,
                 epoch_idx,
                 "dev",
+                tokenizer,
                 best_score,
                 patience,
             )
@@ -1114,6 +1115,7 @@ def train_model(train_data, dev_data, test_data, tokenizer, candidate_generator,
                 test_docs,
                 epoch_idx,
                 "test",
+                tokenizer,
             )
         else:
             logger.info(


### PR DESCRIPTION
 tokenizer parameter was missing in the evaluate() call. It caused an AttributeError: 'NoneType' object has no attribute 'model_max_length'. The issue occurred since tokenizer was not being passed correctly.

```
Traceback (most recent call last):
  File "/..../coref/SECURE/src/models/run_pairwise_classification.py", line 261, in structure_pair
    tokens, token_map, offset_1, offset_2 = tokenize_and_map_pair(
  File "/..../coref/SECURE/src/models/pairwise_classifier.py", line 80, in tokenize_and_map_pair
    max_seq_length = tokenizer.model_max_length
AttributeError: 'NoneType' object has no attribute 'model_max_length'
```